### PR TITLE
Update bug report template to include Logs, Issue Timeline, and Codepath requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -9,9 +9,17 @@ labels: bug
 
 <!-- What's the bug in snarkOS that you found? How serious is this bug and what is affected? -->
 
+## SnarkOS Logs
+
+<!-- Post any SnarkOS logs from the node(s) that experienced the issue. This goes a long way in helping to diagnose the issue! -->
+
 ## Steps to Reproduce
 
 <!-- How do I reproduce this issue in snarkOS? Are there error messages or stack traces that would help debug this issue? -->
+
+## Timeline of Events
+
+<!-- What was the timline of events which lead to this bug -->
 
 ## Expected Behavior
 
@@ -22,3 +30,7 @@ labels: bug
 - <!-- snarkOS Version -->
 - <!-- Rust Version -->
 - <!-- Computer OS -->
+
+## Code Where the Issue Appears
+
+<!-- If you have found the line(s) of code that the issue appears in, please post it here! -->


### PR DESCRIPTION
## Motivation

To help developers debugging on SnarkOS issues, it is helpful to have logs, a timline of event, and any lines of code which are known to cause the issue. This PR adds those things to the bug report template!

[Link to Rendered Version](https://github.com/AleoNet/snarkOS/blob/a5ffe180262b97f2ee7563037e9d28cd79242a77/.github/ISSUE_TEMPLATE/bug.md)